### PR TITLE
Added check for MYSQL_ROOT_PASSWORD_FILE

### DIFF
--- a/etc/cron.daily/docker-mysql-backup
+++ b/etc/cron.daily/docker-mysql-backup
@@ -30,7 +30,7 @@ for container in $(docker ps --format '{{.Names}}\t{{.Image}}'  | /bin/grep '\sm
 do
     BACKUP_DIR="${BACKUP_BASE}/docker_${container}"
     mkdir -p "${BACKUP_DIR}"
-    docker exec "$container" sh -c 'exec mysqldump --all-databases -uroot -p"$MYSQL_ROOT_PASSWORD"' | ${GZIP} -9 > "${BACKUP_DIR}/${NOW}_complete.sql.gz"
+    docker exec "$container" sh -c 'if [ "$MYSQL_ROOT_PASSWORD_FILE" ]; then MYSQL_ROOT_PASSWORD=`cat $MYSQL_ROOT_PASSWORD_FILE`; fi; exec mysqldump --all-databases -uroot -p"$MYSQL_ROOT_PASSWORD"' | ${GZIP} -9 > "${BACKUP_DIR}/${NOW}_complete.sql.gz"
 
     # delete all that are older than 30 days and the date does not end with a 2 -> keep ~3 per month
     for file in $(find $BACKUP_DIR -mtime +30 | grep -v '20..-..-.2_')


### PR DESCRIPTION
Hey @binfalse 

We found your script when looking for a solution to backup databases in our Docker swarm. It works great. We did find that we need to tweak it to support using secrets file. Might be overkill but we wanted to share with you change. Let me know if you have questions about the change or any thoughts.